### PR TITLE
Fixed installation location for consistency with base-logging.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,11 +172,11 @@ configure_file(base_types.pc.in ${CMAKE_BINARY_DIR}/base_types.pc @ONLY)
 install(FILES ${CMAKE_BINARY_DIR}/base_types.pc DESTINATION lib/pkgconfig)
 
 # Install headers
-install(FILES ${BASE_HEADERS_SRC} DESTINATION include/base_types/)
-install(FILES ${BASE_HEADERS_COMMANDS} DESTINATION include/base_types/commands/)
-install(FILES ${BASE_HEADERS_LOGGING} DESTINATION include/base_types/logging/)
-install(FILES ${BASE_HEADERS_SAMPLES} DESTINATION include/base_types/samples/)
-install(FILES ${BASE_HEADERS_TEMPLATES} DESTINATION include/base_types/templates/)
+install(FILES ${BASE_HEADERS_SRC} DESTINATION include/base-types/)
+install(FILES ${BASE_HEADERS_COMMANDS} DESTINATION include/base-types/commands/)
+install(FILES ${BASE_HEADERS_LOGGING} DESTINATION include/base-types/logging/)
+install(FILES ${BASE_HEADERS_SAMPLES} DESTINATION include/base-types/samples/)
+install(FILES ${BASE_HEADERS_TEMPLATES} DESTINATION include/base-types/templates/)
 
 # Install library
 install(TARGETS base_types DESTINATION lib)

--- a/base_types.pc.in
+++ b/base_types.pc.in
@@ -8,5 +8,5 @@ Description: Base types library for robotic applications
 Version: @PROJECT_VERSION@
 Requires: base_logging
 Requires.private: eigen3
-Libs: -L${libdir} -lboost_system -lboost_filesystem
-Cflags: -I${includedir} -I@BOOST_INCLUDEDIR@ -I@EIGEN3_INCLUDE_DIR@
+Libs: -L${libdir} -lbase_types -lbase_logging -lsisl @Boost_SYSTEM_LIBRARY@ @Boost_FILESYSTEM_LIBRARY@
+Cflags: -I${includedir} -I${SISL_INCLUDE_DIR} -I${BASE_LOGGING_INCLUDE_DIRS} -I@BOOST_INCLUDEDIR@ -I@EIGEN3_INCLUDE_DIR@


### PR DESCRIPTION
The _base-logging_ library is installed as _base-logging_, but _base-types_ is installed as _base_types_. For consistency and compatibility with the _[kinematics library](https://github.com/rock-planning/kinematics_library/blob/eu-rise/include/kinematics_library/KinematicsFactory.hpp#L9)_, the installation path should be changed to _base-types_.